### PR TITLE
fix: handle empty refresh token

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,9 @@
 from django.urls import include, path
 
+from users.views import CustomTokenRefreshView
+
 urlpatterns = [
+    path('token/refresh/', CustomTokenRefreshView.as_view(), name='token_refresh'),
     path('', include('dj_rest_auth.urls')),
     path('users/', include('users.urls')),
     path('symptoms/', include('symptoms.urls')),

--- a/symptoms/fixtures/sintomas_categorias.json
+++ b/symptoms/fixtures/sintomas_categorias.json
@@ -12,7 +12,7 @@
         "pk": 2,
         "fields": {
             "identificador": "EYES_DISCONFORT",
-            "pregunta": "¿Tiene molestias en los ojos?"
+            "pregunta": "¿Tuvo molestias en los ojos en el último año?"
         }
     },
     {

--- a/users/admin.py
+++ b/users/admin.py
@@ -25,8 +25,7 @@ class CustomUserAdmin(UserAdmin):
                     'sexo',
                     'fecha_nacimiento',
                     'departamento',
-                    'barrio'
-                    'historial_sintomas',
+                    'barrio',
                     'email',
                     'password'
                 )

--- a/users/tests/test_login.py
+++ b/users/tests/test_login.py
@@ -1,12 +1,13 @@
 from django.test import TestCase, Client, override_settings
 from rest_framework import status
 from faker import Faker
+from django.urls import reverse
 
 from users.tests.factories import UserFactory
 from users.models import User
 import alergias.strings as strings
 
-LOGIN_URL = '/api/v1/login/'
+LOGIN_URL = reverse('rest_login')
 
 
 @override_settings(ACCOUNT_EMAIL_VERIFICATION="optional")
@@ -33,6 +34,7 @@ class TestUserLogin(TestCase):
         response_data = response.data
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNotNone(str(response_data['access_token']))
+        self.assertIsNotNone(str(response_data['refresh_token']))
         self.assertEqual(response_data['user']['email'], response_db.email)
 
     def test_if_user_doesnt_exist_then_should_raise_an_error(self):

--- a/users/tests/test_tokens.py
+++ b/users/tests/test_tokens.py
@@ -1,0 +1,47 @@
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+from django.urls import reverse
+from faker import Faker
+
+from users.tests.factories import UserFactory
+
+
+@override_settings(ACCOUNT_EMAIL_VERIFICATION="optional")
+class TestUserCreation(TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        super().setUpClass()
+        self.client_test = APIClient()
+        self.password = Faker().password
+        self.email = UserFactory(password=self.password).email
+
+    def test_if_try_to_refresh_token_then_access_token_is_returned(self):
+        refresh_token = self.client_test.post(
+            reverse('rest_login'),
+            {
+                'email': self.email,
+                'password': self.password
+            }
+        ).data['refresh_token']
+
+        response = self.client_test.post(
+            reverse('token_refresh'),
+            {
+                'refresh': refresh_token,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(str(response.data['access']))
+
+    def test_if_try_to_refresh_without_token_then_401_is_returned(self):
+        response = self.client_test.post(
+            reverse('token_refresh'),
+            {
+                'refresh': '',
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/users/views.py
+++ b/users/views.py
@@ -7,6 +7,8 @@ from allauth.account.utils import send_email_confirmation
 from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
+from rest_framework_simplejwt.views import TokenRefreshView
+from rest_framework_simplejwt.serializers import TokenRefreshSerializer
 
 from .models import User
 
@@ -30,3 +32,14 @@ class NewEmailConfirmation(APIView):
         else:
             send_email_confirmation(request, user=user, signup=True)
             return Response({'message': 'Email de confirmación enviado'}, status=status.HTTP_201_CREATED)
+
+
+class CustomTokenRefreshView(TokenRefreshView):
+    serializer_class = TokenRefreshSerializer
+
+    def post(self, request, *args, **kwargs):
+        try:
+            return super().post(request, *args, **kwargs)
+
+        except Exception:
+            return Response(status=status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
## Description
- Return 401 instead of 400 when try to refresh the token without `refresh_token`
- Add refresh token tests
- Small fixes